### PR TITLE
Registro no bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 ## Instalação
 
-`npm install --save bra-responsive`
+- via npm: `npm install --save bra-responsive`
+- via bower: `bower install --save bra-responsive`
 
 ## Sobre o BRA responsive
 

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,29 @@
+{
+  "name": "bra-responsive",
+  "description": "Framework front-end para criação de projetos web responsivos e mobile-first",
+  "main": "css/bra.css",
+  "authors": [
+    "CarlosHPS (http://www.carloshps.com.br)"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "bra-responsive",
+    "framework",
+    "css",
+    "grid",
+    "responsive",
+    "web",
+    "carloshps",
+    "front-end",
+    "webdesign",
+    "mobile-first"
+  ],
+  "homepage": "http://www.braresponsive.com.br",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests  "
+  ]
+}


### PR DESCRIPTION
Acabou que eu esqueci de adicionar a biblioteca ao registro de pacotes do bower. É mais fácil que npm ainda, porquê o bower utiliza as tags do github para determinar a versão, ou seja, o `npm run publicar` atual automaticamente irá atualizar o pacote no registro do bower, sem precisar mexer 😄 